### PR TITLE
Q4: ADR Export, What-If Weights, Experiments, Evidence, and Snapshots/Diff (Electron JS MVP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 HOD-MVP-*
+HOD-MVP-Q4-*
 dist
 .DS_Store
 *.log

--- a/docs/Q4-feature-plan.md
+++ b/docs/Q4-feature-plan.md
@@ -1,0 +1,31 @@
+# Q4 Feature Plan (Selected): 2, 3, 5, 6, 8
+
+## Features
+2) **ADR One-Pager Export (Markdown)**
+3) **What-If Weight Slider (Live Recalc)**
+5) **Experiments Board**
+6) **Evidence Attachments (supports/refutes + confidence)**
+8) **Comparison Snapshots + Diff**
+
+## Acceptance Criteria
+- ADR export produces a Markdown file with Context, Outcomes, Constraints, Criteria & Weights, Ranked Options, Assumptions, Evidence, Experiments, Trade-offs.
+- What-If sliders change weights and recompute within 100ms on typical hardware.
+- Experiments board supports CRUD; fields: hypothesis, metric, threshold, status, result.
+- Evidence supports/refutes, confidence 0–1, URL/ref, notes.
+- Snapshots save model + compute results; Diff shows weight and rank changes between latest two snapshots.
+
+## Data Model Additions
+```json
+{
+  "experiments": [{"hypothesis":"","metric":"","threshold":"","status":"Planned|Running|Done","result":""}],
+  "evidence": [{"title":"","url":"","supports":true,"confidence":0.7,"notes":""}],
+  "snapshots": [{"ts":"","model":{...},"results":{"weights":[],"results":[]}}]
+}
+```
+
+## Usage Tips
+1. Enter criteria and options; press **Compute**.
+2. Use **What‑If Weights** to explore sensitivity; press **Compute** again to view impact.
+3. Add **Evidence** and **Experiments** to capture learning loops.
+4. Create **Snapshots** before and after major changes; inspect **Diff**.
+5. **Export ADR** to share a 1‑page rationale in reviews.

--- a/main.js
+++ b/main.js
@@ -4,8 +4,8 @@ const fs = require('fs');
 
 function createWindow () {
   const win = new BrowserWindow({
-    width: 1100,
-    height: 800,
+    width: 1200,
+    height: 860,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
@@ -13,13 +13,11 @@ function createWindow () {
       sandbox: true
     }
   });
-
   win.loadFile(path.join(__dirname, 'src', 'index.html'));
 }
 
 app.whenReady().then(() => {
   createWindow();
-
   app.on('activate', function () {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();
   });
@@ -29,7 +27,6 @@ app.on('window-all-closed', function () {
   if (process.platform !== 'darwin') app.quit();
 });
 
-// Storage helpers
 const dataFile = path.join(app.getPath('userData'), 'decisions.json');
 
 ipcMain.handle('storage:save', async (_event, payload) => {
@@ -47,6 +44,18 @@ ipcMain.handle('storage:load', async () => {
     if (!fs.existsSync(dataFile)) return { ok: true, data: null, path: dataFile };
     const text = fs.readFileSync(dataFile, 'utf-8');
     return { ok: true, data: JSON.parse(text), path: dataFile };
+  } catch (e) {
+    return { ok: false, error: e.message };
+  }
+});
+
+ipcMain.handle('export:adr', async (_event, { markdown }) => {
+  try {
+    const dir = app.getPath('userData');
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const file = path.join(dir, `decision-ADR-${ts}.md`);
+    fs.writeFileSync(file, markdown, 'utf-8');
+    return { ok: true, path: file };
   } catch (e) {
     return { ok: false, error: e.message };
   }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "human-oriented-design-mvp",
-  "version": "0.1.0",
-  "description": "MVP Electron app for structured problem-solving (Human Oriented Design) \u2014 JavaScript only.",
+  "name": "human-oriented-design-mvp-q4",
+  "version": "0.2.0",
+  "description": "Electron MVP upgraded with Q4 features (ADR export, what-if weights, experiments, evidence, snapshots).",
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "package-win": "electron-packager . HOD-MVP --platform=win32 --arch=x64 --overwrite",
-    "package-mac": "electron-packager . HOD-MVP --platform=darwin --arch=arm64 --overwrite",
-    "package-linux": "electron-packager . HOD-MVP --platform=linux --arch=x64 --overwrite"
+    "package-win": "electron-packager . HOD-MVP-Q4 --platform=win32 --arch=x64 --overwrite",
+    "package-mac": "electron-packager . HOD-MVP-Q4 --platform=darwin --arch=arm64 --overwrite",
+    "package-linux": "electron-packager . HOD-MVP-Q4 --platform=linux --arch=x64 --overwrite"
   },
   "author": "You",
   "license": "MIT",

--- a/src/index.html
+++ b/src/index.html
@@ -3,22 +3,22 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>HOD MVP – Structured Decisions</title>
+  <title>HOD MVP – Q4 Workbench</title>
   <link rel="stylesheet" href="./styles.css"/>
 </head>
 <body>
   <header>
-    <h1>Human Oriented Design – MVP Workbench</h1>
+    <h1>Human Oriented Design – Q4 Workbench</h1>
     <p class="subtitle">Frame → Compare → Decide → Learn</p>
   </header>
 
   <section class="grid two">
     <div class="card">
       <h2>Problem & Outcomes</h2>
-      <label>Problem <textarea id="problem" placeholder="e.g., Reduce build times for the analytics app"></textarea></label>
-      <label>Outcomes (metrics + targets) <textarea id="outcomes" placeholder="p95_build_time < 6m; release cadence weekly"></textarea></label>
-      <label>Constraints <textarea id="constraints" placeholder="$5k/mo infra cap; must keep on-prem data"></textarea></label>
-      <label>Assumptions (+confidence 0–1) <textarea id="assumptions" placeholder="Remote cache persists across CI (0.6)"></textarea></label>
+      <label>Problem <textarea id="problem"></textarea></label>
+      <label>Outcomes (metrics + targets) <textarea id="outcomes"></textarea></label>
+      <label>Constraints <textarea id="constraints"></textarea></label>
+      <label>Assumptions (+confidence 0–1) <textarea id="assumptions"></textarea></label>
     </div>
 
     <div class="card">
@@ -28,6 +28,13 @@
         <tbody></tbody>
       </table>
       <button id="addCriteria">+ Add criterion</button>
+
+      <div class="whatif">
+        <h3>What‑If Weights</h3>
+        <p class="hint">Adjust temporary weights below to explore sensitivity (auto-normalized).</p>
+        <div id="whatIfSliders"></div>
+        <button id="resetWhatIf">Reset What‑If</button>
+      </div>
     </div>
   </section>
 
@@ -45,17 +52,45 @@
       <h2>Compute & Results</h2>
       <button id="computeBtn">Compute Ranking</button>
       <div id="results"></div>
+      <div class="adr">
+        <h3>ADR Export</h3>
+        <button id="exportAdrBtn">Export ADR (Markdown)</button>
+        <div id="adrStatus"></div>
+      </div>
     </div>
+
     <div class="card">
-      <h2>Persistence</h2>
+      <h2>Persistence & Snapshots</h2>
       <button id="saveBtn">Save</button>
       <button id="loadBtn">Load</button>
+      <button id="snapshotBtn">Create Snapshot</button>
       <div id="status"></div>
+      <div id="snapshots"></div>
+    </div>
+  </section>
+
+  <section class="grid two">
+    <div class="card">
+      <h2>Experiments Board</h2>
+      <table id="experimentsTable" class="table">
+        <thead><tr><th>Hypothesis</th><th>Metric</th><th>Threshold</th><th>Status</th><th>Result</th><th></th></tr></thead>
+        <tbody></tbody>
+      </table>
+      <button id="addExperiment">+ Add experiment</button>
+    </div>
+
+    <div class="card">
+      <h2>Evidence</h2>
+      <table id="evidenceTable" class="table">
+        <thead><tr><th>Title</th><th>URL/Ref</th><th>Supports?</th><th>Confidence (0–1)</th><th>Notes</th><th></th></tr></thead>
+        <tbody></tbody>
+      </table>
+      <button id="addEvidence">+ Add evidence</button>
     </div>
   </section>
 
   <footer>
-    <p>Local-first. No TypeScript. Simple Additive Weighting. v0.1</p>
+    <p>Local-first. No TypeScript. Q4 features: ADR, What-if, Experiments, Evidence, Snapshots.</p>
   </footer>
 
   <script src="./renderer.js"></script>

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -7,14 +7,30 @@ const resultsDiv = document.getElementById('results');
 const saveBtn = document.getElementById('saveBtn');
 const loadBtn = document.getElementById('loadBtn');
 const statusDiv = document.getElementById('status');
+const whatIfWrap = document.getElementById('whatIfSliders');
+const resetWhatIfBtn = document.getElementById('resetWhatIf');
+
+const exportAdrBtn = document.getElementById('exportAdrBtn');
+const adrStatus = document.getElementById('adrStatus');
+
+const experimentsBody = document.querySelector('#experimentsTable tbody');
+const addExperimentBtn = document.getElementById('addExperiment');
+
+const evidenceBody = document.querySelector('#evidenceTable tbody');
+const addEvidenceBtn = document.getElementById('addEvidence');
+
+const snapshotsDiv = document.getElementById('snapshots');
+const snapshotBtn = document.getElementById('snapshotBtn');
+
+let whatIfWeights = null;
 
 function addCriterionRow(name='', weight=0) {
   const tr = document.createElement('tr');
   tr.innerHTML = `
-    <td><input type="text" class="crit-name" placeholder="e.g., Speed" value="${name}"></td>
+    <td><input type="text" class="crit-name" placeholder="e.g., Info Gain" value="${name}"></td>
     <td><input type="number" class="crit-weight" min="0" max="100" step="1" value="${weight}"></td>
     <td><button class="del">Delete</button></td>`;
-  tr.querySelector('.del').onclick = () => tr.remove();
+  tr.querySelector('.del').onclick = () => { tr.remove(); renderOptionScores(); renderWhatIf(); };
   criteriaBody.appendChild(tr);
 }
 
@@ -60,6 +76,99 @@ function renderOptionScores() {
   });
 }
 
+// Experiments
+function addExperimentRow(ex={hypothesis:'',metric:'',threshold:'',status:'Planned',result:''}) {
+  const tr = document.createElement('tr');
+  tr.innerHTML = `
+    <td><input type="text" class="ex-hyp" placeholder="Hypothesis" value="${ex.hypothesis||''}"></td>
+    <td><input type="text" class="ex-metric" placeholder="Metric" value="${ex.metric||''}"></td>
+    <td><input type="text" class="ex-threshold" placeholder="Threshold" value="${ex.threshold||''}"></td>
+    <td>
+      <select class="ex-status">
+        <option ${ex.status==='Planned'?'selected':''}>Planned</option>
+        <option ${ex.status==='Running'?'selected':''}>Running</option>
+        <option ${ex.status==='Done'?'selected':''}>Done</option>
+      </select>
+    </td>
+    <td><input type="text" class="ex-result" placeholder="Result notes" value="${ex.result||''}"></td>
+    <td><button class="del">Delete</button></td>
+  `;
+  tr.querySelector('.del').onclick = () => tr.remove();
+  experimentsBody.appendChild(tr);
+}
+
+function currentExperiments() {
+  return Array.from(experimentsBody.querySelectorAll('tr')).map(tr => ({
+    hypothesis: tr.querySelector('.ex-hyp').value.trim(),
+    metric: tr.querySelector('.ex-metric').value.trim(),
+    threshold: tr.querySelector('.ex-threshold').value.trim(),
+    status: tr.querySelector('.ex-status').value,
+    result: tr.querySelector('.ex-result').value.trim()
+  })).filter(ex => ex.hypothesis);
+}
+
+// Evidence
+function addEvidenceRow(ev={title:'',url:'',supports:true,confidence:'',notes:''}) {
+  const tr = document.createElement('tr');
+  tr.innerHTML = `
+    <td><input type="text" class="ev-title" placeholder="Title" value="${ev.title||''}"></td>
+    <td><input type="text" class="ev-url" placeholder="URL or ref" value="${ev.url||''}"></td>
+    <td>
+      <select class="ev-supports">
+        <option value="true" ${ev.supports!==false?'selected':''}>supports</option>
+        <option value="false" ${ev.supports===false?'selected':''}>refutes</option>
+      </select>
+    </td>
+    <td><input type="number" class="ev-conf" min="0" max="1" step="0.1" value="${ev.confidence ?? ''}"></td>
+    <td><input type="text" class="ev-notes" placeholder="Notes" value="${ev.notes||''}"></td>
+    <td><button class="del">Delete</button></td>
+  `;
+  tr.querySelector('.del').onclick = () => tr.remove();
+  evidenceBody.appendChild(tr);
+}
+
+function currentEvidence() {
+  return Array.from(evidenceBody.querySelectorAll('tr')).map(tr => ({
+    title: tr.querySelector('.ev-title').value.trim(),
+    url: tr.querySelector('.ev-url').value.trim(),
+    supports: tr.querySelector('.ev-supports').value === 'true',
+    confidence: Number(tr.querySelector('.ev-conf').value || 0),
+    notes: tr.querySelector('.ev-notes').value.trim()
+  })).filter(ev => ev.title);
+}
+
+// What-If
+function renderWhatIf() {
+  whatIfWrap.innerHTML = '';
+  const crits = currentCriteria();
+  if (!crits.length) return;
+  const used = whatIfWeights && whatIfWeights.length === crits.length ? whatIfWeights : crits.map(c => ({ name: c.name, weight: c.weight }));
+  whatIfWeights = used;
+  used.forEach((c, idx) => {
+    const row = document.createElement('div');
+    row.className = 'slider';
+    row.innerHTML = `
+      <span>${c.name}</span>
+      <input type="range" class="wi-range" min="0" max="100" step="1" value="${c.weight}">
+      <input type="number" class="wi-num" min="0" max="100" step="1" value="${c.weight}">
+    `;
+    const range = row.querySelector('.wi-range');
+    const num = row.querySelector('.wi-num');
+    function update(val) {
+      whatIfWeights[idx].weight = Number(val);
+      num.value = val;
+      computeAndRender(true);
+    }
+    range.oninput = (e) => update(e.target.value);
+    num.oninput = (e) => { range.value = e.target.value; update(e.target.value); };
+    whatIfWrap.appendChild(row);
+  });
+}
+
+resetWhatIfBtn.onclick = () => { whatIfWeights = null; renderWhatIf(); computeAndRender(false); };
+
+// Model
+let currentSnapshots = [];
 function modelFromUI() {
   const model = {
     problem: document.getElementById('problem').value.trim(),
@@ -67,7 +176,10 @@ function modelFromUI() {
     constraints: document.getElementById('constraints').value.trim(),
     assumptions: document.getElementById('assumptions').value.trim(),
     criteria: currentCriteria(),
-    options: currentOptions()
+    options: currentOptions(),
+    experiments: currentExperiments(),
+    evidence: currentEvidence(),
+    snapshots: currentSnapshots
   };
   return model;
 }
@@ -82,26 +194,32 @@ function populateUI(model) {
   optionsBody.innerHTML = '';
   (model.options || []).forEach(o => addOptionRow(o.name));
   renderOptionScores();
-  // fill scores
   (model.options || []).forEach((o, i) => {
     const tr = optionsBody.querySelectorAll('tr')[i];
     if (!tr) return;
-    const scoresCell = tr.querySelector('.scores');
-    Array.from(scoresCell.querySelectorAll('.score')).forEach(inp => {
+    Array.from(tr.querySelectorAll('.score')).forEach(inp => {
       const key = inp.dataset.crit;
       if (o.scores && o.scores[key] != null) inp.value = o.scores[key];
     });
   });
+  experimentsBody.innerHTML = '';
+  (model.experiments || []).forEach(addExperimentRow);
+  evidenceBody.innerHTML = '';
+  (model.evidence || []).forEach(addEvidenceRow);
+  currentSnapshots = model.snapshots || [];
+  renderSnapshots();
+  whatIfWeights = null;
+  renderWhatIf();
 }
 
-addCriteriaBtn.onclick = () => { addCriterionRow(); renderOptionScores(); };
-addOptionBtn.onclick = () => addOptionRow();
-
-computeBtn.onclick = () => {
+// Compute & Results
+let lastComputeOut = { results: [], weights: [] };
+function computeAndRender(usingWhatIf=false) {
   const model = modelFromUI();
-  const res = window.hod.compute(model);
+  const override = usingWhatIf && whatIfWeights ? whatIfWeights : null;
+  const res = window.hod.compute(model, override);
   const list = document.createElement('div');
-  list.innerHTML = `<p><strong>Normalized weights</strong>:</p>`;
+  list.innerHTML = `<p><strong>${override ? 'What‑If' : 'Normalized'} weights</strong>:</p>`;
   res.weights.forEach(w => {
     const badge = document.createElement('span');
     badge.className = 'badge';
@@ -121,8 +239,12 @@ computeBtn.onclick = () => {
   resultsDiv.innerHTML = '';
   resultsDiv.appendChild(list);
   resultsDiv.appendChild(table);
-};
+  lastComputeOut = res;
+}
 
+computeBtn.onclick = () => computeAndRender(Boolean(whatIfWeights));
+
+// Persistence
 saveBtn.onclick = async () => {
   const model = modelFromUI();
   const out = await window.hod.save(model);
@@ -141,23 +263,147 @@ loadBtn.onclick = async () => {
   }
 };
 
-// Seed with a small example for first run
+// ADR Export
+function renderADRMarkdown(model, computeOut) {
+  const weightsLines = (computeOut.weights||[]).map(w => `- ${w.name}: ${(w.w*100).toFixed(1)}%`).join('\n');
+  const resultsLines = (computeOut.results||[]).map((r,i)=> `${i+1}. **${r.name}** — ${r.total.toFixed(3)}`).join('\n');
+  const evLines = (model.evidence||[]).map(ev => `- [${ev.supports ? 'supports' : 'refutes'}] ${ev.title} (${ev.confidence ?? '?'}) — ${ev.url || ''}`).join('\n');
+  const exLines = (model.experiments||[]).map(ex => `- **${ex.hypothesis}** → metric: ${ex.metric} threshold: ${ex.threshold} status: ${ex.status || 'Planned'}`).join('\n');
+  return [
+    `# Architecture Decision Record — ${new Date().toISOString().slice(0,10)}`,
+    ``,
+    `**Context / Problem**: ${model.problem || ''}`,
+    ``,
+    `**Outcomes (targets)**: ${model.outcomes || ''}`,
+    `**Constraints**: ${model.constraints || ''}`,
+    ``,
+    `## Criteria & Weights`,
+    weightsLines,
+    ``,
+    `## Options Ranked (SAW 0–5)`,
+    resultsLines,
+    ``,
+    model.assumptions?.trim() ? '## Assumptions\n' + model.assumptions + '\n' : '',
+    (model.evidence||[]).length ? '## Evidence\n' + evLines + '\n' : '',
+    (model.experiments||[]).length ? '## Experiments\n' + exLines + '\n' : '',
+    `## Trade-offs & Decision`,
+    model.rationale || '_Add rationale & trade-offs here._',
+    ``
+  ].join('\n');
+}
+
+exportAdrBtn.onclick = async () => {
+  const model = modelFromUI();
+  if (!lastComputeOut.results.length) {
+    lastComputeOut = window.hod.compute(model);
+  }
+  const md = renderADRMarkdown(model, lastComputeOut);
+  const out = await window.hod.exportADR(md);
+  adrStatus.textContent = out.ok ? `ADR saved to ${out.path}` : `Error: ${out.error}`;
+};
+
+// Snapshots + Diff
+function createSnapshot() {
+  const model = modelFromUI();
+  const computeOut = window.hod.compute(model, whatIfWeights || null);
+  const snap = {
+    ts: new Date().toISOString(),
+    model: JSON.parse(JSON.stringify(model)),
+    results: computeOut
+  };
+  currentSnapshots.push(snap);
+  renderSnapshots();
+}
+
+function renderSnapshots() {
+  snapshotsDiv.innerHTML = '<h3>Snapshots</h3>';
+  if (!currentSnapshots.length) {
+    snapshotsDiv.innerHTML += '<p class="hint">No snapshots yet.</p>';
+    return;
+  }
+  const list = document.createElement('ul');
+  currentSnapshots.forEach((s, idx) => {
+    const li = document.createElement('li');
+    li.innerHTML = `<strong>${idx+1}</strong> — ${s.ts}`;
+    list.appendChild(li);
+  });
+  snapshotsDiv.appendChild(list);
+
+  if (currentSnapshots.length >= 2) {
+    const a = currentSnapshots[currentSnapshots.length - 2];
+    const b = currentSnapshots[currentSnapshots.length - 1];
+    const diffText = diffSnapshots(a, b);
+    const pre = document.createElement('div');
+    pre.className = 'diff';
+    pre.textContent = diffText;
+    snapshotsDiv.appendChild(pre);
+  }
+}
+
+function diffSnapshots(a, b) {
+  function weightsMap(snap) {
+    const comps = snap.results.weights || window.hod.normalizeWeights(snap.model.criteria);
+    const m = {}; comps.forEach(w => m[w.name] = w.w); return m;
+  }
+  function rankMap(snap) {
+    const m = {}; (snap.results.results||[]).forEach((r,i)=> m[r.name]=i+1); return m;
+  }
+  const wa = weightsMap(a), wb = weightsMap(b);
+  const ka = Object.keys(wa), kb = Object.keys(wb);
+  const allCrit = Array.from(new Set([...ka, ...kb]));
+  const lines = [];
+  lines.push('— Weights change —');
+  allCrit.forEach(k => {
+    const va = (wa[k]||0)*100, vb = (wb[k]||0)*100;
+    if (Math.abs(va - vb) > 0.01) lines.push(`${k}: ${va.toFixed(1)}% → ${vb.toFixed(1)}%`);
+  });
+  lines.push('\n— Rank change —');
+  const ra = rankMap(a), rb = rankMap(b);
+  const allOpts = Array.from(new Set([...Object.keys(ra), ...Object.keys(rb)]));
+  allOpts.forEach(o => {
+    const pa = ra[o] || '-', pb = rb[o] || '-';
+    if (pa !== pb) lines.push(`${o}: #${pa} → #${pb}`);
+  });
+  if (lines.length <= 2) return 'No significant changes.';
+  return lines.join('\n');
+}
+
+snapshotBtn.onclick = createSnapshot;
+
+// Buttons & Seed
+addCriteriaBtn.onclick = () => { addCriterionRow(); renderOptionScores(); renderWhatIf(); };
+addOptionBtn.onclick = () => addOptionRow();
+addExperimentBtn.onclick = () => addExperimentRow();
+addEvidenceBtn.onclick = () => addEvidenceRow();
+
 window.addEventListener('DOMContentLoaded', () => {
   populateUI({
-    problem: "Reduce build times for the analytics app",
-    outcomes: "p95_build_time < 6m; release weekly",
-    constraints: "$5k/mo infra cap",
-    assumptions: "Remote cache persists across CI (0.6)",
+    problem: "Prioritize Q4 features for HOD MVP",
+    outcomes: "Maximize validated learning (decisions made faster, clearer)",
+    constraints: "JavaScript only; local-first; small scope",
+    assumptions: "Teams will adopt a lightweight ADR if exported in 2 clicks (0.6)",
     criteria: [
-      { name: "Speed", weight: 40 },
-      { name: "Cost", weight: 25 },
-      { name: "Complexity", weight: 20 },
-      { name: "Risk", weight: 15 }
+      { name: "Info Gain", weight: 30 },
+      { name: "Speed to Insight", weight: 20 },
+      { name: "Risk Coverage", weight: 20 },
+      { name: "Feasibility", weight: 15 },
+      { name: "Signal Quality", weight: 15 }
     ],
     options: [
-      { name: "Remote cache + Gradle", scores: { Speed: 5, Cost: 3, Complexity: 3, Risk: 3 } },
-      { name: "Bazel migration",       scores: { Speed: 4, Cost: 2, Complexity: 2, Risk: 2 } },
-      { name: "Parallelize CI",        scores: { Speed: 3, Cost: 4, Complexity: 4, Risk: 4 } }
-    ]
+      { name: "ADR One-Pager Export",       scores: { "Info Gain": 4, "Speed to Insight": 5, "Risk Coverage": 3, "Feasibility": 5, "Signal Quality": 4 } },
+      { name: "What-If Weight Slider",      scores: { "Info Gain": 4, "Speed to Insight": 4, "Risk Coverage": 4, "Feasibility": 4, "Signal Quality": 4 } },
+      { name: "Experiments Board",          scores: { "Info Gain": 5, "Speed to Insight": 3, "Risk Coverage": 4, "Feasibility": 3, "Signal Quality": 4 } },
+      { name: "Evidence Attachments",       scores: { "Info Gain": 4, "Speed to Insight": 3, "Risk Coverage": 4, "Feasibility": 3, "Signal Quality": 5 } },
+      { name: "Comparison Snapshots + Diff",scores: { "Info Gain": 3, "Speed to Insight": 3, "Risk Coverage": 4, "Feasibility": 4, "Signal Quality": 3 } }
+    ],
+    experiments: [
+      { hypothesis: "What-if slider reduces debate time by focusing on weights", metric: "decision_time_minutes", threshold: "≤ 30", status: "Planned", result: "" }
+    ],
+    evidence: [
+      { title: "Team review feedback", url: "", supports: true, confidence: 0.7, notes: "People want a 1‑pager." }
+    ],
+    snapshots: []
   });
+  computeAndRender(false);
+  renderWhatIf();
 });

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,19 +1,23 @@
-:root { --fg: #111; --bg: #fff; --muted:#666; --card:#f7f7f8; --border:#ddd; }
-* { box-sizing: border-box; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
-body { margin: 0; color: var(--fg); background: var(--bg); }
-header { padding: 1.2rem 1.2rem 0.6rem; border-bottom: 1px solid var(--border); }
-h1 { margin: 0; font-size: 1.3rem; }
-.subtitle { margin: 0.2rem 0 0.5rem; color: var(--muted); }
-.grid.two { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; padding: 1rem; }
-.card { background: var(--card); border: 1px solid var(--border); padding: 1rem; border-radius: 12px; }
-label { display: block; margin-bottom: 0.5rem; font-size: 0.95rem; }
-textarea { width: 100%; min-height: 70px; resize: vertical; padding: 0.5rem; border:1px solid var(--border); border-radius: 8px; }
-.table { width: 100%; border-collapse: collapse; background: white; border-radius: 8px; overflow: hidden; border:1px solid var(--border); }
-.table th, .table td { border-bottom: 1px solid var(--border); padding: 0.5rem; vertical-align: top; }
-.table th { background: #fafafa; text-align: left; }
-input[type="text"], input[type="number"] { width: 100%; padding: 0.4rem; border:1px solid var(--border); border-radius: 6px; }
-button { padding: 0.5rem 0.8rem; border-radius: 8px; border:1px solid var(--border); background: white; cursor: pointer; }
-button:hover { background: #f0f0f0; }
-#results { margin-top: 0.6rem; }
-footer { padding: 0.8rem 1.2rem; color: var(--muted); }
+:root { --fg:#111; --bg:#fff; --muted:#666; --card:#f7f7f8; --border:#ddd; }
+* { box-sizing:border-box; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
+body { margin:0; color:var(--fg); background:var(--bg); }
+header { padding: 1.2rem 1.2rem 0.6rem; border-bottom:1px solid var(--border); }
+h1 { margin:0; font-size:1.25rem; }
+h2 { margin-top:0; }
+.subtitle { margin:0.2rem 0 0.5rem; color:var(--muted); }
+.grid.two { display:grid; grid-template-columns: 1fr 1fr; gap:1rem; padding:1rem; }
+.card { background:var(--card); border:1px solid var(--border); padding:1rem; border-radius:12px; }
+label { display:block; margin-bottom:0.5rem; font-size:0.95rem; }
+textarea { width:100%; min-height:70px; resize:vertical; padding:0.5rem; border:1px solid var(--border); border-radius:8px; }
+.table { width:100%; border-collapse: collapse; background:white; border-radius:8px; overflow:hidden; border:1px solid var(--border); }
+.table th, .table td { border-bottom:1px solid var(--border); padding:0.5rem; vertical-align: top; }
+.table th { background:#fafafa; text-align:left; }
+input[type="text"], input[type="number"], select { width:100%; padding:0.4rem; border:1px solid var(--border); border-radius:6px; }
+button { padding:0.5rem 0.8rem; border-radius:8px; border:1px solid var(--border); background:white; cursor:pointer; }
+button:hover { background:#f0f0f0; }
 .badge { display:inline-block; padding:0.2rem 0.45rem; border-radius:999px; border:1px solid var(--border); background:#fff; margin-right:0.3rem; font-size:0.8rem; }
+.hint { color:var(--muted); font-size:0.9rem; }
+.whatif { margin-top:0.8rem; background:white; border:1px dashed var(--border); padding:0.6rem; border-radius:10px; }
+.slider { display:grid; grid-template-columns: 120px 1fr 60px; gap:0.4rem; align-items:center; margin-bottom:0.3rem; }
+footer { padding:0.8rem 1.2rem; color:var(--muted); }
+.diff { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; font-size: 12px; white-space: pre-wrap; background: #fff; border: 1px solid var(--border); padding: 0.5rem; border-radius: 8px; }


### PR DESCRIPTION
Adds fast-learning features to the Human Oriented Design MVP to prioritize Q4 learning/validation:

* ADR one-pager export (Markdown)
* What-If weight sliders with live recompute
* Experiments board (hypothesis → metric → threshold → status/result)
* Evidence attachments (supports/refutes + confidence)
* Comparison snapshots + textual diff (weights & rank shifts)

{Motivation / Context}
We’re optimizing for **Learning / market validation (D)**. These features make assumptions, trade-offs, and outcomes explicit, reduce debate by focusing on weights, and create a reviewable decision record.

{Scope of Changes}

* New UI surfaces for What-If, Experiments, Evidence, and Snapshots
* ADR export via IPC to Markdown in Electron `userData`
* Compute flow accepts temporary weight overrides; results panel shows normalized vs What-If weights
* Persistence model extended (backwards compatible)

{Implementation Notes}

* **IPC:** `export:adr` saves ADR Markdown to `userData`
* **Preload:** exposes `compute(model, weightsOverride)`, `normalizeWeights`, `exportADR(markdown)`
* **Security:** `contextIsolation: true`, `nodeIntegration: false`, `sandbox: true` (unchanged)
* **Computation:** Simple Additive Weighting (SAW); weights auto-normalize; scores 0–5

{Data Model Additions}

```json
{
  "experiments": [
    { "hypothesis": "", "metric": "", "threshold": "", "status": "Planned|Running|Done", "result": "" }
  ],
  "evidence": [
    { "title": "", "url": "", "supports": true, "confidence": 0.0, "notes": "" }
  ],
  "snapshots": [
    { "ts": "", "model": { /* saved model */ }, "results": { "weights": [], "results": [] } }
  ]
}
```

{How to Run}

```bash
npm install
npm start
```

{Manual Test Plan}

1. Seed a decision (problem, 3–6 criteria, ≥2 options).
2. Move **What-If** sliders → click **Compute** → confirm ranks update instantly.
3. Click **Create Snapshot**, adjust weights, **Create Snapshot** again → verify **Diff** shows weight % and rank changes.
4. Add an **Experiment** (hypothesis/metric/threshold/status/result).
5. Add **Evidence** (supports/refutes + confidence + URL).
6. Click **Export ADR** → confirm `.md` saved in `userData` with Context, Outcomes, Constraints, Criteria & Weights, Ranked Options, Assumptions, Evidence, Experiments, Trade-offs.

{Acceptance Criteria}

* ADR includes all sections above and reflects current compute output.
* What-If sliders recompute within \~100ms on typical hardware.
* Experiments/Evidence support add/edit/delete and persist on Save/Load.
* Snapshots store model + results; Diff shows deltas between the last two snapshots.
* No regression to base compute/persistence.

{Backward Compatibility}

* Existing saves load; new arrays (`experiments`, `evidence`, `snapshots`) are optional. No migrations required.

{Known Limitations}

* ADR export is Markdown only (no in-app PDF renderer).
* Sensitivity charts are textual (no graphing lib).
* No multi-user sync yet.

{Follow-ups / Future Work}

* ADR → PDF/HTML export styling
* Visual sensitivity (tornado) and per-criterion what-if ranges
* Evidence ledger views (supports/refutes totals, confidence heat)
* Local-first sync/backup

{Checklist}

* [x] Feature flags not required (MVP)
* [x] Preload API documented in code
* [x] Manual test plan included
* [x] Security posture unchanged
* [x] Backwards compatibility confirmed
